### PR TITLE
Replace deprecated libraries for index conversion in QuantumBayesian.jl

### DIFF
--- a/src/QuantumBayesian.jl
+++ b/src/QuantumBayesian.jl
@@ -31,8 +31,8 @@ import Base.setindex!
 import Base.ndims
 import Base.indices
 import Base.print_matrix
-import Base.sub2ind
-import Base.ind2sub
+import Base.IteratorsMD
+import Base.LinearIndices
 import Base.map
 import Statistics.mean
 import Statistics.median


### PR DESCRIPTION
Include Base.IteratorsMD and Base.LinearIndices to replace ind2sub and sub2ind